### PR TITLE
jdbc:h2:file:/tmp/testdb works

### DIFF
--- a/demo/src/main/resources/application.properties
+++ b/demo/src/main/resources/application.properties
@@ -1,1 +1,7 @@
+spring.datasource.url=jdbc:h2:file:/tmp/testdb
+spring.datasource.username=sa
+spring.datasource.password=pw
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
 


### PR DESCRIPTION
Followed error messages and cludes in: https://www.baeldung.com/spring-boot-h2-database

Seemed to really need the:
```
spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
```

Also, note that this creates this file:
-rw-r--r--  1 mpayne  wheel  16384 Mar  8 21:14 /tmp/testdb.mv.db

And there's a second one while the `./gradlew bootRun` is running